### PR TITLE
Fix #50

### DIFF
--- a/src/main/java/org/ow2/chameleon/core/Constants.java
+++ b/src/main/java/org/ow2/chameleon/core/Constants.java
@@ -89,6 +89,12 @@ public class Constants {
      */
     public static final String CHAMELEON_AUTO_REFRESH = "chameleon.auto.refresh";
 
+    /**
+     * The property used to allowed chameleon keep running if it starts in interactive mode and shelbie disapear.
+     * By defaut , false
+     */
+    public static final String CHAMELEON_INTERACTIVE_SHUTDOWN = "chameleon.enable.interactive.shutdown";
+
     private Constants() {
         // Avoid direct instantiation
     }

--- a/src/main/java/org/ow2/chameleon/core/utils/FrameworkManager.java
+++ b/src/main/java/org/ow2/chameleon/core/utils/FrameworkManager.java
@@ -88,7 +88,7 @@ public class FrameworkManager {
     public Framework start() throws BundleException {
         framework.init();
 
-        if (configuration.isInteractiveModeEnabled()) {
+        if (configuration.isInteractiveModeEnabled() && (!(configuration.getBoolean(Constants.CHAMELEON_INTERACTIVE_SHUTDOWN,false)))) {
             // The interactive mode is enabled, to avoid issue during the stopping sequence we listen for a specific
             // event
             try {


### PR DESCRIPTION
Add chameleon property to allowed shutdown of the shell in interactive mode.
Exit shelbie command just exit shell and not the platform when this property is set to true.